### PR TITLE
Fixed the glitch which causes multiple results to show one below another

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,7 +163,8 @@ const ep_data_fill = async(season_id)=>{
     console.log(episode_data.data[0])
     const l = episode_data.data.length
     headers.innerHTML = heads;
-    console.log(headers);
+    //console.log(headers);
+    table.append(headers);
     for(var i=0; i<l; i++){
         var number = episode_data.data[i].number;
         var date = episode_data.data[i].airdate;


### PR DESCRIPTION
Fixed the glitch which caused the stacking of multiple results one below another + table showing old tv show episodes not new ones.
This was caused by searching multiple times for results.


Old ▽
![Old Search res](https://user-images.githubusercontent.com/56192025/136570436-b4ddc665-0c9a-458e-82cd-219b2c5d1fbd.png)


New ▽
![New Fixed stuff](https://user-images.githubusercontent.com/56192025/136570473-c637fd1f-59ee-4096-8263-d72678c5ec70.png)
