### PR TITLE
Fixed a logical mistake in clearing cast table

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ function clear_old_data(){
     document.getElementById('show-image').innerHTML="";
     document.getElementById('show-prim-info').innerHTML="";
     document.getElementById('data-table').innerHTML="";
+    document.getElementById('cast_data').innerHTML="";
 }
 
 //FORM SUBMISSION EVENT LISTENER


### PR DESCRIPTION
I had forgotten to clear the cast table in the clear_data function which sometimes caused the cast table to keep showing old data n loading a new show while the old one's cast table was open 
![image](https://user-images.githubusercontent.com/56192025/136703270-a4c09c7f-10d7-4388-bd2b-afd73837a5a5.png)

I know it's a one line change but I noticed it after deployment so I apologise.