### PR TITLE
💄 Style: fix nav bar so it shows on mobile for index and movies pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta2/css/all.min.css" integrity="sha512-YWzhKL2whUzgiheMoBFwW8CKV4qpHQAEuvilg9FAn5VJUDwKZZxkJNuGM4XkWuk94WCrrwslk8yWNGmY1EduTA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <title>HacktoberFest</title>
-       <link rel="shortcut icon" href="images/favicon.ico" />
+    <link rel="shortcut icon" href="images/favicon.ico" />
   </head>
   <body style="background: #2D6967">
 
@@ -48,23 +48,22 @@
     </div>
     
     <header class="site-navbar" role="banner">
-        
+
       <!-- NAVBAR STARTS -->
       <div class="container">
         <div class="head-row align-items-center">
-            <!-- style="position: relative; top: 3px; display: inline-block;" -->
             <div class="d-inline-block d-xl-none ml-md-0 mr-auto py-3" ><a href="#" class="site-menu-toggle js-menu-toggle text-white"><span class="icon-menu h3"></span></a></div>
           
           <div class="col-11 col-xl-2">
-            <div style = "display: flex;">
+            <div style = "display: flex; justify-content: center;">
               <img src = ".\images\logo.png" height="50" width="50" style="margin-right: 20px;">
             <h1 text-align="center"><a href="index.html" class="text-white mb-0" style="font-family: Hacktoberfest; font-weight: bolder;">HacktoberFest</a></h1>
           </div>
         </div>
-          <div class="col-12 col-md-10 d-none d-xl-block">
+          <div class="col-12 col-md-10 d-xl-block">
             <nav class="site-navigation position-relative text-right" role="navigation">
 
-              <ul class="site-menu js-clone-nav mr-auto d-none d-lg-block">
+              <ul class="site-menu js-clone-nav mr-auto d-lg-block">
                 <li class="active"><a href="index.html"><span>TV</span></a></li>
                 <li><a href="movies.html"><span>Movies</span></a></li>
                 <li><a href="explore.html"><span>Explore</span></a></li>

--- a/movies.html
+++ b/movies.html
@@ -54,33 +54,30 @@
   </div>
 
   <header class="site-navbar" role="banner">
+<!-- NAVBAR STARTS -->
+<div class="container">
+  <div class="head-row align-items-center">
+    <div class="d-inline-block d-xl-none ml-md-0 mr-auto py-3"><a href="#"
+        class="site-menu-toggle js-menu-toggle text-white"><span class="icon-menu h3"></span></a></div>
 
-    <!-- NAVBAR STARTS -->
-    <div class="container">
-      <div class="head-row align-items-center">
-        <!-- style="position: relative; top: 3px; display: inline-block;" -->
-        <div class="d-inline-block d-xl-none ml-md-0 mr-auto py-3"><a href="#"
-            class="site-menu-toggle js-menu-toggle text-white"><span class="icon-menu h3"></span></a></div>
+    <div class="col-11 col-xl-2">
+      <div style="display: flex; justify-content: center;">
+        <img src=".\images\logo.png" height="50" width="50" style="margin-right: 20px;">
+        <h1 text-align="center"><a href="index.html" class="text-white mb-0"
+            style="font-family: Hacktoberfest; font-weight: bolder;">HacktoberFest</a></h1>
+      </div>
+    </div>
+    <div class="col-12 col-md-10 d-xl-block">
+      <nav class="site-navigation position-relative text-right" role="navigation">
 
-        <div class="col-11 col-xl-2">
-          <div style="display: flex;">
-            <img src=".\images\logo.png" height="50" width="50" style="margin-right: 20px;">
-            <h1 text-align="center"><a href="index.html" class="text-white mb-0"
-                style="font-family: Hacktoberfest; font-weight: bolder;">HacktoberFest</a></h1>
-          </div>
-        </div>
-        <div class="col-12 col-md-10 d-none d-xl-block">
-          <nav class="site-navigation position-relative text-right" role="navigation">
-
-            <ul class="site-menu js-clone-nav mr-auto d-none d-lg-block">
-              <li><a href="index.html"><span>TV</span></a></li>
-              <li class="active"><a href="movies.html"><span>Movies</span></a></li>
-              <li><a href="explore.html"><span>Explore</span></a></li>
-              <li><a href="discover.html"><span>Discover</span></a></li>
-            </ul>
-          </nav>
-        </div>
-
+        <ul class="site-menu js-clone-nav mr-auto d-lg-block">
+          <li class="active"><a href="index.html"><span>TV</span></a></li>
+          <li><a href="movies.html"><span>Movies</span></a></li>
+          <li><a href="explore.html"><span>Explore</span></a></li>
+          <li><a href="discover.html"><span>Discover</span></a></li>
+        </ul>
+      </nav>
+    </div>
 
         <!-- <div class="d-inline-block d-xl-none ml-md-0 mr-auto py-3" style="position: relative; top: 3px;"><a href="#" class="site-menu-toggle js-menu-toggle text-white"><span class="icon-menu h3"></span></a></div> -->
 

--- a/style.css
+++ b/style.css
@@ -181,21 +181,32 @@ th{
 }
 
 .container .head-row {
-display: flex;
-justify-content: space-between;
-flex-direction: row;
-  flex-wrap: nowrap;
+  display: flex;
+  flex-direction: column;
 }
 
-@media (max-width: 979px) {
-  .container .head-row {
-    justify-content: flex-start;
-    margin: 0 20px;
-    }
+nav ul {
+  padding: 0;
+  margin: 1rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
 
-    form#searchForm {
-      width: 80%;
-    }
+@media (min-width: 979px) {
+  header .container {
+    max-width: 100%;
+  }
+  .container .head-row {
+    flex-direction: row;
+    justify-content: space-evenly;
+  }
+  form#searchForm {
+    width: 80%;
+  }
+  .head-row>div {
+    max-width: fit-content;
+  }
 }
 
 #main-info{display:flex;}


### PR DESCRIPTION
This PR addresses[ issue 161](https://github.com/ietebitmesra/Hacktoberfest_21/issues/161)

I removed `display: none` that was preventing the nav bar from showing on certain pages and styled it with responsive design and mobile first (see screenshots.) I wasn't sure if it should show on the other 2 pages as well but it can easily be added in the same way just LMK. 

Mobile:
![Hacktober Test](https://user-images.githubusercontent.com/28207315/137600186-293873d7-e545-42af-a512-d7c620e30e7d.png)

Desktop:
![Hack-tobertest](https://user-images.githubusercontent.com/28207315/137600188-9b1810b2-e1d7-49b7-9aff-8ea3129f8fdc.png)
